### PR TITLE
ci(tui): add fetch-tags to checkout steps for semantic versioning

### DIFF
--- a/.github/workflows/tui-pr.yml
+++ b/.github/workflows/tui-pr.yml
@@ -75,6 +75,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
+          fetch-tags: true
 
       - name: Calculate version
         id: version

--- a/.github/workflows/tui-release.yml
+++ b/.github/workflows/tui-release.yml
@@ -77,6 +77,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
+          fetch-tags: true
 
       - name: Calculate version
         id: version


### PR DESCRIPTION
## Summary

- Add `fetch-tags: true` to checkout steps that precede `PaulHatch/semantic-version`
- `actions/checkout@v4` defaults to `fetch-tags: false`, so even with `fetch-depth: 0` tags aren't fetched, causing the version action to warn about missing valid tags

🤖 Generated with [Claude Code](https://claude.com/claude-code)