### PR TITLE
ci(api): enable corepack in release workflow

### DIFF
--- a/.github/workflows/api-release.yml
+++ b/.github/workflows/api-release.yml
@@ -53,6 +53,9 @@ jobs:
           cache: true
           experimental: true
 
+      - name: Enable corepack
+        run: corepack enable
+
       - name: Install dependencies
         working-directory: api
         run: pnpm install --frozen-lockfile


### PR DESCRIPTION
## Summary
- Adds `corepack enable` step before `pnpm install` in the API release workflow
- Fixes `pnpm: command not found` failure introduced when the graceful shutdown commit triggered a release

## Context
Mise installs Node.js but doesn't activate corepack. Since pnpm is managed via the `packageManager` field in `package.json`, corepack must be explicitly enabled to make the `pnpm` binary available.

🤖 Generated with [Claude Code](https://claude.com/claude-code)