### PR TITLE
fix(tui): point default api url to public instance

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -75,7 +75,7 @@ A cryptoquip game inspired by syndicated newspaper puzzles. Players decode encry
 
 - **Framework**: Bubble Tea (Elm architecture for Go)
 - **Styling**: Lip Gloss
-- **Configuration**: `UNQUOTE_API_URL` env var (default: `http://localhost:3000`)
+- **Configuration**: `UNQUOTE_API_URL` env var (default: `https://unquote.gaur-kardashev.ts.net`)
 
 ### TUI Development (run from `tui/`)
 - `go build -o bin/unquote ./main.go` - Build binary

--- a/tui/CLAUDE.md
+++ b/tui/CLAUDE.md
@@ -31,7 +31,7 @@ From `tui/` directory:
 ### api package
 - **Exposes**: `Client`, `NewClient()`, `NewClientWithURL(url)`
 - **Guarantees**: Wraps all API errors with context
-- **Expects**: API at `UNQUOTE_API_URL` env var (default: `http://localhost:3000`)
+- **Expects**: API at `UNQUOTE_API_URL` env var (default: `https://unquote.gaur-kardashev.ts.net`)
 
 ### puzzle package
 - **Exposes**: `Cell`, `BuildCells()`, cell navigation functions, `AssembleSolution()`
@@ -74,7 +74,7 @@ From `tui/` directory:
 
 | Variable | Required | Default | Description |
 |----------|----------|---------|-------------|
-| `UNQUOTE_API_URL` | No | http://localhost:3000 | API base URL |
+| `UNQUOTE_API_URL` | No | https://unquote.gaur-kardashev.ts.net | API base URL |
 
 ## CI/CD Workflows
 

--- a/tui/internal/api/client.go
+++ b/tui/internal/api/client.go
@@ -11,7 +11,7 @@ import (
 )
 
 const (
-	defaultBaseURL = "http://localhost:3000"
+	defaultBaseURL = "https://unquote.gaur-kardashev.ts.net"
 	defaultTimeout = 5 * time.Second
 	envAPIURL      = "UNQUOTE_API_URL"
 )


### PR DESCRIPTION
## Summary
- Change default TUI API base URL from `http://localhost:3000` to `https://unquote.gaur-kardashev.ts.net` (public Tailscale Funnel endpoint)
- Update documentation in `CLAUDE.md` and `tui/CLAUDE.md` to reflect the new default
- Users can still override via `UNQUOTE_API_URL` for local development

🤖 Generated with [Claude Code](https://claude.com/claude-code)