### PR TITLE
ci(tui): pass semver tag to goreleaser for monorepo releases

### DIFF
--- a/.github/workflows/tui-release.yml
+++ b/.github/workflows/tui-release.yml
@@ -123,4 +123,5 @@ jobs:
           workdir: tui
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GORELEASER_CURRENT_TAG: v${{ steps.version.outputs.version }}
           BUILD_BRANCH: main


### PR DESCRIPTION
## Summary
- Fix goreleaser release failure caused by scoped tag `tui-v0.1.1` not being valid semver
- Pass `GORELEASER_CURRENT_TAG=v<version>` (prefix stripped) so goreleaser sees a valid semver tag
- Matches the pattern already used in the PR snapshot workflow
- GoReleaser OSS doesn't support the `monorepo` config block (Pro only), so the env var override is the correct approach

🤖 Generated with [Claude Code](https://claude.com/claude-code)