### PR TITLE
fix(api): add configurable CORS origin and trust proxy support

### DIFF
--- a/api/packages/api/src/config/schema.ts
+++ b/api/packages/api/src/config/schema.ts
@@ -27,6 +27,16 @@ export const EnvSchema = Type.Object({
 
   // Optional: OpenTelemetry OTLP endpoint
   OTEL_EXPORTER_OTLP_ENDPOINT: Type.Optional(Type.String()),
+
+  // CORS allowed origins (comma-separated list, or "*" for all)
+  CORS_ORIGIN: Type.String({
+    default: "*",
+  }),
+
+  // Trust proxy headers (X-Forwarded-For, etc.)
+  TRUST_PROXY: Type.Boolean({
+    default: false,
+  }),
 });
 
 /**

--- a/api/packages/api/src/index.ts
+++ b/api/packages/api/src/index.ts
@@ -26,6 +26,7 @@ const buildServer = async (): Promise<FastifyInstance> => {
     logger: {
       level: process.env["LOG_LEVEL"] ?? "info",
     },
+    trustProxy: process.env["TRUST_PROXY"] === "true",
     ajv: {
       plugins: [oas3PluginAjv],
     },
@@ -41,8 +42,9 @@ const buildServer = async (): Promise<FastifyInstance> => {
     contentSecurityPolicy: false,
   });
 
+  const corsOrigin = fastify.config.CORS_ORIGIN;
   await fastify.register(cors, {
-    origin: true,
+    origin: corsOrigin === "*" ? true : corsOrigin.split(",").map((o) => o.trim()),
   });
 
   await fastify.register(underPressure, {


### PR DESCRIPTION
## Summary
- Add `CORS_ORIGIN` env var (default `"*"`) to control allowed origins instead of reflecting any requesting origin with `origin: true`. Supports comma-separated allowlist (e.g. `https://example.com,https://app.example.com`).
- Add `TRUST_PROXY` env var (default `false`) to configure Fastify's `trustProxy`, ensuring `request.ip` uses `X-Forwarded-For` behind reverse proxies so rate limiting applies per-client rather than sharing one bucket.

🤖 Generated with [Claude Code](https://claude.com/claude-code)