### PR TITLE
fix(api): harden input validation with strict schemas and size limits

### DIFF
--- a/api/packages/api/src/domain/game/routes/schemas.ts
+++ b/api/packages/api/src/domain/game/routes/schemas.ts
@@ -6,10 +6,13 @@ import { schemaType } from "@eropple/fastify-openapi3";
  */
 export const HintSchema = schemaType(
   "Hint",
-  Type.Object({
-    cipherLetter: Type.String({ minLength: 1, maxLength: 1 }),
-    plainLetter: Type.String({ minLength: 1, maxLength: 1 }),
-  }),
+  Type.Object(
+    {
+      cipherLetter: Type.String({ minLength: 1, maxLength: 1 }),
+      plainLetter: Type.String({ minLength: 1, maxLength: 1 }),
+    },
+    { additionalProperties: false },
+  ),
 );
 
 export type Hint = Static<typeof HintSchema>;
@@ -19,14 +22,17 @@ export type Hint = Static<typeof HintSchema>;
  */
 export const PuzzleResponseSchema = schemaType(
   "PuzzleResponse",
-  Type.Object({
-    id: Type.String({ description: "Opaque game ID for solution checking" }),
-    date: Type.String({ format: "date", description: "ISO date (YYYY-MM-DD)" }),
-    encryptedText: Type.String({ description: "Encrypted quote text" }),
-    author: Type.String({ description: "Quote author" }),
-    difficulty: Type.Number({ minimum: 0, maximum: 100 }),
-    hints: Type.Array(HintSchema),
-  }),
+  Type.Object(
+    {
+      id: Type.String({ description: "Opaque game ID for solution checking" }),
+      date: Type.String({ format: "date", description: "ISO date (YYYY-MM-DD)" }),
+      encryptedText: Type.String({ description: "Encrypted quote text" }),
+      author: Type.String({ description: "Quote author" }),
+      difficulty: Type.Number({ minimum: 0, maximum: 100 }),
+      hints: Type.Array(HintSchema),
+    },
+    { additionalProperties: false },
+  ),
 );
 
 export type PuzzleResponse = Static<typeof PuzzleResponseSchema>;
@@ -36,12 +42,15 @@ export type PuzzleResponse = Static<typeof PuzzleResponseSchema>;
  */
 export const DateParamsSchema = schemaType(
   "DateParams",
-  Type.Object({
-    date: Type.String({
-      format: "date",
-      description: "Date in ISO format (YYYY-MM-DD)",
-    }),
-  }),
+  Type.Object(
+    {
+      date: Type.String({
+        format: "date",
+        description: "Date in ISO format (YYYY-MM-DD)",
+      }),
+    },
+    { additionalProperties: false },
+  ),
 );
 
 export type DateParams = Static<typeof DateParamsSchema>;
@@ -51,9 +60,12 @@ export type DateParams = Static<typeof DateParamsSchema>;
  */
 export const GameIdParamsSchema = schemaType(
   "GameIdParams",
-  Type.Object({
-    id: Type.String({ description: "Opaque game ID" }),
-  }),
+  Type.Object(
+    {
+      id: Type.String({ description: "Opaque game ID" }),
+    },
+    { additionalProperties: false },
+  ),
 );
 
 export type GameIdParams = Static<typeof GameIdParamsSchema>;
@@ -63,9 +75,16 @@ export type GameIdParams = Static<typeof GameIdParamsSchema>;
  */
 export const CheckRequestSchema = schemaType(
   "CheckRequest",
-  Type.Object({
-    solution: Type.String({ minLength: 1, description: "User's decoded text" }),
-  }),
+  Type.Object(
+    {
+      solution: Type.String({
+        minLength: 1,
+        maxLength: 5000,
+        description: "User's decoded text",
+      }),
+    },
+    { additionalProperties: false },
+  ),
 );
 
 export type CheckRequest = Static<typeof CheckRequestSchema>;
@@ -75,9 +94,12 @@ export type CheckRequest = Static<typeof CheckRequestSchema>;
  */
 export const CheckResponseSchema = schemaType(
   "CheckResponse",
-  Type.Object({
-    correct: Type.Boolean(),
-  }),
+  Type.Object(
+    {
+      correct: Type.Boolean(),
+    },
+    { additionalProperties: false },
+  ),
 );
 
 export type CheckResponse = Static<typeof CheckResponseSchema>;

--- a/api/packages/api/src/index.ts
+++ b/api/packages/api/src/index.ts
@@ -29,6 +29,7 @@ const buildServer = async (): Promise<FastifyInstance> => {
     ajv: {
       plugins: [oas3PluginAjv],
     },
+    bodyLimit: 1_048_576,
   }).withTypeProvider<TypeBoxTypeProvider>();
 
   // Register environment configuration first (validates and populates fastify.config)


### PR DESCRIPTION
## Summary
- Add `additionalProperties: false` to all `Type.Object()` route schemas to reject unexpected fields (prevents `__proto__` injection)
- Add `maxLength: 5000` to the `solution` string in `CheckRequestSchema` to prevent multi-MB payloads
- Set explicit `bodyLimit: 1_048_576` (1MB) on the Fastify constructor for defense-in-depth

🤖 Generated with [Claude Code](https://claude.com/claude-code)