### PR TITLE
fix(ci): fix release workflow tag issues for TUI and API

### DIFF
--- a/.github/workflows/tui-release.yml
+++ b/.github/workflows/tui-release.yml
@@ -98,6 +98,9 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
+      - name: Create temporary unprefixed tag for GoReleaser
+        run: git tag "v${{ steps.version.outputs.version }}"
+
       - name: Setup mise
         uses: jdx/mise-action@v3
         with:
@@ -125,3 +128,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GORELEASER_CURRENT_TAG: v${{ steps.version.outputs.version }}
           BUILD_BRANCH: main
+
+      - name: Clean up temporary tag
+        if: always()
+        run: git tag -d "v${{ steps.version.outputs.version }}" || true


### PR DESCRIPTION
## Summary

- **TUI release**: GoReleaser OSS requires `GORELEASER_CURRENT_TAG` to match a real git tag. The workflow creates `tui-v*` prefixed tags but passes unprefixed `v*` to GoReleaser, causing validation failure. Adds a temporary local-only lightweight tag before GoReleaser runs and cleans it up afterward.
- **API Docker release**: The Docker workflow triggered on `api-v*` tag pushes, but `GITHUB_TOKEN` events don't trigger other workflows. Replaces the tag trigger with `workflow_call` so `api-release.yml` calls the Docker workflow directly, passing the version. Docker images now get semver tags (e.g. `1.2.3`, `1.2`) on release, in addition to `latest` and `main-<sha>` on every push to main.

🤖 Generated with [Claude Code](https://claude.com/claude-code)