### PR TITLE
fix(api): silence health check request logging on success

### DIFF
--- a/api/packages/api/src/routes/health.ts
+++ b/api/packages/api/src/routes/health.ts
@@ -24,6 +24,7 @@ export const healthRoutes: FastifyPluginAsync = async (fastify) => {
   }>({
     method: "GET",
     url: "/",
+    logLevel: "warn",
     schema: {
       response: {
         200: HealthResponseSchema,


### PR DESCRIPTION
## Summary

- Set `logLevel: "warn"` on the `/health` route so successful 200 responses don't produce request logs
- Reduces noise from load balancer and Docker healthcheck probes
- Errors (5xx) on the health endpoint still log normally

🤖 Generated with [Claude Code](https://claude.com/claude-code)