### PR TITLE
ci: remove custom semantic-version pattern workarounds

### DIFF
--- a/.github/workflows/api-release.yml
+++ b/.github/workflows/api-release.yml
@@ -118,8 +118,6 @@ jobs:
         with:
           tag_prefix: "api-v"
           change_path: "api/"
-          major_pattern: "/^\\w+(\\(.*\\))?!:/"
-          minor_pattern: "/^feat(\\(.*\\))?:/"
           version_format: "${major}.${minor}.${patch}"
 
       - name: Create and push tag

--- a/.github/workflows/tui-pr.yml
+++ b/.github/workflows/tui-pr.yml
@@ -113,8 +113,6 @@ jobs:
         with:
           tag_prefix: "v"
           change_path: "tui/"
-          major_pattern: "/^\\w+(\\(.*\\))?!:/"
-          minor_pattern: "/^feat(\\(.*\\))?:/"
           version_format: "${major}.${minor}.${patch}"
 
       - name: Setup mise

--- a/.github/workflows/tui-release.yml
+++ b/.github/workflows/tui-release.yml
@@ -105,8 +105,6 @@ jobs:
         with:
           tag_prefix: "v"
           change_path: "tui/"
-          major_pattern: "/^\\w+(\\(.*\\))?!:/"
-          minor_pattern: "/^feat(\\(.*\\))?:/"
           version_format: "${major}.${minor}.${patch}"
 
       - name: Create and push tag


### PR DESCRIPTION
## Summary

- Removes custom `major_pattern` and `minor_pattern` overrides from all three workflows using `PaulHatch/semantic-version`
- v6.0.1 (PaulHatch/semantic-version#188) fixed the default patterns to support optional conventional commit scopes natively
- The new default `major_pattern` also improves detection by matching `BREAKING CHANGE:` in commit bodies, not just `type!:`

🤖 Generated with [Claude Code](https://claude.com/claude-code)