### PR TITLE
build(tui): switch macos builds to universal binary

### DIFF
--- a/.github/workflows/tui-pr.yml
+++ b/.github/workflows/tui-pr.yml
@@ -158,18 +158,11 @@ jobs:
           path: tui/dist/unquote_*_linux_arm64.tar.gz
           retention-days: 7
 
-      - name: Upload macOS amd64
+      - name: Upload macOS universal
         uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6.0.0
         with:
-          name: unquote-macos-amd64
-          path: tui/dist/unquote_*_darwin_amd64.tar.gz
-          retention-days: 7
-
-      - name: Upload macOS arm64
-        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6.0.0
-        with:
-          name: unquote-macos-arm64
-          path: tui/dist/unquote_*_darwin_arm64.tar.gz
+          name: unquote-macos-universal
+          path: tui/dist/unquote_*_darwin_all.tar.gz
           retention-days: 7
 
       - name: Upload Windows amd64
@@ -205,7 +198,7 @@ jobs:
 
             **Platforms built:**
             - Linux (amd64, arm64)
-            - macOS (amd64, arm64)
+            - macOS (universal)
             - Windows (amd64)
 
             [Download artifacts](https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }})

--- a/tui/.goreleaser.yml
+++ b/tui/.goreleaser.yml
@@ -30,6 +30,9 @@ builds:
       - -X 'github.com/bojanrajkovic/unquote/tui/internal/version.Commit={{.ShortCommit}}'
       - -X 'github.com/bojanrajkovic/unquote/tui/internal/version.Date={{.Date}}'
 
+universal_binaries:
+  - replace: true
+
 archives:
   - id: default
     formats:

--- a/tui/CLAUDE.md
+++ b/tui/CLAUDE.md
@@ -94,7 +94,7 @@ Triggered automatically when you open a PR that modifies files in `tui/` or `.gi
 
 3. **Build Snapshot** - Runs after CI passes
    - Calculates alpha version from commit history
-   - Builds cross-platform binaries via goreleaser (Linux amd64/arm64, macOS amd64/arm64, Windows amd64)
+   - Builds cross-platform binaries via goreleaser (Linux amd64/arm64, macOS universal, Windows amd64)
    - Uploads artifacts to GitHub Actions (7-day retention)
    - Posts/updates PR comment with download links
 


### PR DESCRIPTION
## Summary

- Add GoReleaser `universal_binaries` config to produce a single macOS fat binary (amd64 + arm64) instead of separate per-arch builds
- Update PR workflow to upload one macOS universal artifact instead of two
- Update `tui/CLAUDE.md` build description

Closes #53.

🤖 Generated with [Claude Code](https://claude.com/claude-code)