### PR TITLE
feat: add quote category to puzzle response and tui display

### DIFF
--- a/api/packages/api/src/domain/game/routes/puzzle.ts
+++ b/api/packages/api/src/domain/game/routes/puzzle.ts
@@ -34,6 +34,7 @@ async function generatePuzzleResponse(
     date: dateStr,
     encryptedText: puzzle.encryptedText,
     author: quote.author,
+    category: quote.category,
     difficulty: quote.difficulty,
     hints: puzzle.hints.map((hint) => ({
       cipherLetter: hint.cipherLetter.toUpperCase(),

--- a/api/packages/api/src/domain/game/routes/schemas.ts
+++ b/api/packages/api/src/domain/game/routes/schemas.ts
@@ -28,6 +28,7 @@ export const PuzzleResponseSchema = schemaType(
       date: Type.String({ format: "date", description: "ISO date (YYYY-MM-DD)" }),
       encryptedText: Type.String({ description: "Encrypted quote text" }),
       author: Type.String({ description: "Quote author" }),
+      category: Type.String({ description: "Quote category (e.g. inspiration, humor)" }),
       difficulty: Type.Number({ minimum: 0, maximum: 100 }),
       hints: Type.Array(HintSchema),
     },

--- a/tui/internal/api/types.go
+++ b/tui/internal/api/types.go
@@ -12,6 +12,7 @@ type Puzzle struct {
 	Date          string `json:"date"`
 	EncryptedText string `json:"encryptedText"`
 	Author        string `json:"author"`
+	Category      string `json:"category"`
 	Hints         []Hint `json:"hints"`
 	Difficulty    int    `json:"difficulty"`
 }

--- a/tui/internal/app/view.go
+++ b/tui/internal/app/view.go
@@ -99,9 +99,9 @@ func (m Model) viewError() string {
 func (m Model) viewPlaying() string {
 	header := m.renderHeader()
 
-	// Difficulty
+	// Category and Difficulty
 	diffText := puzzle.DifficultyText(m.puzzle.Difficulty)
-	difficulty := ui.DifficultyStyle.Render(fmt.Sprintf("Difficulty: %s", diffText))
+	difficulty := ui.DifficultyStyle.Render(fmt.Sprintf("%s · Difficulty: %s", m.puzzle.Category, diffText))
 
 	// Timer
 	timer := ui.TimerStyle.Render(fmt.Sprintf("Time: %s", formatElapsed(m.Elapsed())))


### PR DESCRIPTION
## Summary

- Adds the `category` field (e.g. "inspiration", "humor") to the puzzle API response — it was already on the `Quote` type but not exposed
- Updates the TUI to display category alongside difficulty in the playing view