### PR TITLE
ci: fix claude code review workflow

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -24,9 +24,10 @@ jobs:
 
       - name: Run Claude Code Review
         uses: anthropics/claude-code-action@ea36d6abdedc17fc2a671b36060770b208a6f8f1 # v1.0.51
+        env:
+          DISPLAY_REPORT: "false"
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           plugin_marketplaces: 'https://github.com/anthropics/claude-code.git'
           plugins: 'code-review@claude-code-plugins'
           prompt: '/code-review:code-review ${{ github.repository }}/pull/${{ github.event.pull_request.number }}'
-          display_report: "false"


### PR DESCRIPTION
## Summary
- Upgrade `pull-requests` permission from `read` to `write` so the action can post review comments on PRs
- Set `display_report: "false"` to suppress the detailed tool-call summary from the Actions run summary tab

🤖 Generated with [Claude Code](https://claude.com/claude-code)