### PR TITLE
fix(web): align stats chart date window with api's utc game dates

### DIFF
--- a/web/src/routes/stats/+page.svelte
+++ b/web/src/routes/stats/+page.svelte
@@ -47,13 +47,17 @@
       solveMap.set(s.date, s.completionTime);
     }
 
-    // Build 30-day window (today back 29 days)
-    const today = new Date();
-    today.setHours(0, 0, 0, 0);
+    // Build 30-day window (today back 29 days).
+    // Use UTC to match the API, which dates games by UTC day.
+    const now = new Date();
+    const todayUTC = Date.UTC(
+      now.getUTCFullYear(),
+      now.getUTCMonth(),
+      now.getUTCDate(),
+    );
     const days: Array<{ date: string; ms: number | null }> = [];
     for (let i = 29; i >= 0; i--) {
-      const d = new Date(today);
-      d.setDate(d.getDate() - i);
+      const d = new Date(todayUTC - i * 86_400_000);
       const key = d.toISOString().slice(0, 10);
       days.push({ date: key, ms: solveMap.get(key) ?? null });
     }


### PR DESCRIPTION
## Summary

- Stats chart built its 30-day date window using local time (`setHours(0,0,0,0)` + `setDate()`), but the API dates games by UTC day
- For users in UTC-minus timezones playing after midnight UTC, the most recent solve's date fell one day past the chart window's right edge, making it invisible
- This caused broken streak lines (gap between consecutive days) and the wrong solve time appearing as the rightmost point
- Fixed by using `Date.UTC()` arithmetic so the chart window matches the API's date system

🤖 Generated with [Claude Code](https://claude.com/claude-code)