### PR TITLE
ci: align Renovate config with mcp-paprika

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -139,9 +139,12 @@
       "automergeType": "pr"
     },
     {
-      "description": "Require manual review for major updates",
+      "description": "Require manual review for major updates (except GitHub Actions)",
       "matchUpdateTypes": [
         "major"
+      ],
+      "matchManagers": [
+        "!github-actions"
       ],
       "automerge": false
     }

--- a/renovate.json
+++ b/renovate.json
@@ -8,7 +8,6 @@
     "before 7am on Monday",
     "before 7am on Thursday"
   ],
-  "prHourlyLimit": 2,
   "prConcurrentLimit": 10,
   "minimumReleaseAge": "3 days",
   "packageRules": [
@@ -57,11 +56,12 @@
       "semanticCommitScope": ""
     },
     {
-      "description": "Group all GitHub Actions together",
+      "description": "Group all GitHub Actions together and automerge all updates",
       "matchManagers": [
         "github-actions"
       ],
-      "groupName": "github actions"
+      "groupName": "github actions",
+      "automerge": true
     },
     {
       "description": "Group OpenTelemetry packages",


### PR DESCRIPTION
Remove `prHourlyLimit: 2` — this was throttling Renovate to 2 PRs/hour during scheduled runs, causing updates to pile up across windows. Automerge all GitHub Actions updates including major bumps, consistent with mcp-paprika.

🤖 Generated with [Claude Code](https://claude.com/claude-code)